### PR TITLE
Checking isCurrent on RouteObserver before updating state

### DIFF
--- a/lib/src/navigation.dart
+++ b/lib/src/navigation.dart
@@ -14,17 +14,16 @@ class SavedStateRouteObserver extends RouteObserver<PageRoute<dynamic>> {
 
   @override
   void didPush(Route route, Route previousRoute) {
-    savedState.putString("_current_route", route?.settings?.name);
+    if(route?.isCurrent == true){
+      savedState.putString("_current_route", route?.settings?.name);
+    }
   }
 
   @override
   void didRemove(Route route, Route previousRoute) {
-    savedState.putString("_current_route", previousRoute?.settings?.name);
-  }
-
-  @override
-  void didReplace({Route newRoute, Route oldRoute}) {
-    savedState.putString("_current_route", newRoute?.settings?.name);
+    if(previousRoute?.isCurrent == true){
+      savedState.putString("_current_route", previousRoute?.settings?.name);
+    }
   }
 
   /// Returns the saved route name or null

--- a/test/route_observer_test.dart
+++ b/test/route_observer_test.dart
@@ -50,6 +50,9 @@ void main() {
 
       observer.didPush(_MockRoute("new"), _MockRoute("old"), );
       expect(SavedStateRouteObserver.restoreRoute(state), "new");
+
+      observer.didPush(_MockRoute("below", isCurrent: false), null, );
+      expect(SavedStateRouteObserver.restoreRoute(state), "new");
     });
 
     test('didRemove saves route correctly', () async {
@@ -61,23 +64,23 @@ void main() {
 
       observer.didRemove(_MockRoute("old"), _MockRoute("new"));
       expect(SavedStateRouteObserver.restoreRoute(state), "new");
-    });
 
-    test('didReplace saves route correctly', () async {
-      var state = await SavedStateData.restore();
-      var observer = SavedStateRouteObserver(savedState: state);
-
-      observer.didReplace(oldRoute: _MockRoute("old"), newRoute: null);
-      expect(SavedStateRouteObserver.restoreRoute(state), null);
-
-      observer.didReplace(oldRoute: _MockRoute("old"), newRoute: _MockRoute("new"));
+      observer.didRemove(_MockRoute("old", isCurrent: false), _MockRoute("below", isCurrent: false));
       expect(SavedStateRouteObserver.restoreRoute(state), "new");
     });
   });
 }
 
 class _MockRoute extends PageRoute {
-  _MockRoute(String name) : super(settings: RouteSettings(name: name));
+  _MockRoute(
+    String name, {
+    bool isCurrent: true,
+  }) : _isCurrent = isCurrent,
+        super(settings: RouteSettings(name: name));
+
+  final bool _isCurrent;
+  @override
+  bool get isCurrent => _isCurrent;
 
   @override
   Color get barrierColor => throw UnimplementedError();


### PR DESCRIPTION
From #16.

Well, I was checking the documentation for some other possibilities, and I think the observer shouldn't listen for `didReplace`, as it's meant for routes that are not visible. See [`replace method`](https://api.flutter.dev/flutter/widgets/Navigator/replace.html).

In addition, `didRemove` should also consider `isCurrent`, because we might remove a route other than the top one.